### PR TITLE
mathjax: v3.2.2 bump to fix \dots redering issue

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -514,13 +514,13 @@ third_party_libraries:
     version: "1.9.4"
   mathjax:
     integrity:
-      js: "sha256-rjmgmaB99riUNcdlrDtcAiwtLIojSxNyUFdl+Qh+rB4="
+      js: "sha256-MASABpB4tYktI2Oitl4t+78w/lyA+D7b/s9GEP0JOGI="
     local:
       fonts: "output/chtml/fonts/woff-v2/"
     url:
       fonts: "https://cdn.jsdelivr.net/npm/mathjax@{{version}}/es5/output/chtml/fonts/woff-v2/"
-      js: "https://cdn.jsdelivr.net/npm/mathjax@{{version}}/es5/tex-mml-chtml.min.js"
-    version: "3.2.0"
+      js: "https://cdn.jsdelivr.net/npm/mathjax@{{version}}/es5/tex-mml-chtml.js"
+    version: "3.2.2"
   masonry:
     integrity:
       js: "sha256-Nn1q/fx0H7SNLZMQ5Hw5JLaTRZp0yILA/FRexe19VdI="


### PR DESCRIPTION
Looks like there is an issue with rendering some equations (I tracked this down to `\dots` causing a parse error, i.e. using `\cdots` is fine),
![2024-07-17-112808_grim](https://github.com/user-attachments/assets/772bad3a-c45a-4557-b3a7-8338ee8561bc)
but fortunately bumping mathjax from 3.2.0 to 3.2.2 solves the issue.

P.S. seems to have been cause by a wrong hash - https://github.com/alshedivat/al-folio/commit/d019fc0f18d51c7c378f34e4432b38529b506ead (not sure why replacing `\dots` with `\cdots` helps - it seems to use either katex or mathjax, anyway..)